### PR TITLE
ci: add workflow_dispatch for manual trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v*'


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` to `ci.yml` and `release.yml`
- Allows manual triggering via GitHub Actions UI
- Does not affect existing push/PR/tag triggers

## Test plan
- [ ] Verify manual trigger button appears in Actions tab
- [ ] Run CI manually and confirm it succeeds
- [ ] Confirm push/PR triggers still work